### PR TITLE
Check for config[:policyfile] being nil before reading

### DIFF
--- a/lib/chef/knife/changelog.rb
+++ b/lib/chef/knife/changelog.rb
@@ -17,7 +17,7 @@ class Chef
 
       def initialize(options)
         super
-        @changelog = if File.exists?(config[:policyfile])
+        @changelog = if config[:policyfile] && File.exists?(config[:policyfile])
                        KnifeChangelog::Changelog::Policyfile.new(config[:policyfile], config)
                      else
                        berksfile = Berkshelf::Berksfile.from_options({})


### PR DESCRIPTION
File.exist? will raise an exception if the value tested is nil, which
it is when used in a non-policyfile environment