### PR TITLE
Fix bug when generating changelog on all updated cookbooks in a policy

### DIFF
--- a/lib/knife/changelog/policyfile.rb
+++ b/lib/knife/changelog/policyfile.rb
@@ -17,7 +17,7 @@ class KnifeChangelog
       end
 
       def all_cookbooks
-        policy.all_possible_dep_names
+        policy.solution_dependencies.cookbook_deps_for_lock.map { |k, v| k.scan(/(.*) \(.*\)/).last.first }
       end
 
       # return true if cookbook is not already listed as dependency

--- a/spec/unit/changelog_spec.rb
+++ b/spec/unit/changelog_spec.rb
@@ -147,6 +147,32 @@ describe KnifeChangelog::Changelog do
         expect { changelog.run(%w[outdated1]) }.to raise_error(NotImplementedError)
       end
     end
+
+    context 'whith --allow-update-all ' do
+      let(:options) do
+        { "allow_update_all": true }
+      end
+
+      it 'should compute the changelog of all dependencies' do
+        mock_git('second_out_of_date', <<-EOH)
+            aaaaaa commit in second_out_of_date
+            bbbbbb bugfix in second_out_of_date
+        EOH
+        mock_git('outdated1', <<-EOH)
+            aaaaaa commit in outdated1
+            bbbbbb bugfix in outdated1
+        EOH
+        mock_git('uptodate', '')
+
+        expect(changelog).to receive(:supermarkets_for).with('outdated1')
+          .and_return(["https://mysupermarket2.io"])
+        expect(changelog).to receive(:supermarkets_for).with('second_out_of_date')
+          .and_return(["https://mysupermarket2.io"])
+        expect(changelog).to receive(:supermarkets_for).with('uptodate')
+          .and_return(["https://mysupermarket2.io"])
+        changelog.run([])
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The method all_possible_dep_names of ChefDK::PolicyfileCompiler is a private
method. Therefore, using the --allow-update-all made the application
crash unexpectedly since it tried to use the private method to compute
the list of all dependencies.

We now compute the list from the dependency graph computed by the
compiler.