### PR TITLE
Show changelog without dependencies by default

### DIFF
--- a/lib/chef/knife/changelog.rb
+++ b/lib/chef/knife/changelog.rb
@@ -48,6 +48,12 @@ class Chef
              description: 'Link to policyfile, defaults to "Policyfile.rb"',
              default: 'Policyfile.rb'
 
+      option :with_dependencies,
+             long: '--with-dependencies',
+             description: 'Show changelog for cookbook in Policyfile with dependencies',
+             boolean: true,
+             default: false
+
       option :update,
              long: '--update',
              description: 'Update Berksfile'
@@ -55,7 +61,11 @@ class Chef
       def run
         Log.info config
         if config[:policyfile] && File.exist?(config[:policyfile])
-          puts PolicyChangelog.new(@name_args, config[:policyfile]).generate_changelog
+          puts PolicyChangelog.new(
+            @name_args,
+            config[:policyfile],
+            config[:with_dependencies]
+          ).generate_changelog
         else
           berksfile = Berkshelf::Berksfile.from_options({})
           puts KnifeChangelog::Changelog::Berksfile

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PolicyChangelog do
   end
 
   let(:changelog) do
-    PolicyChangelog.new('users', File.join(pf_dir, 'Policyfile.rb'))
+    PolicyChangelog.new('users', File.join(pf_dir, 'Policyfile.rb'), false)
   end
 
   let(:lock_current) do


### PR DESCRIPTION
The option --with-dependencies should be used to display a list of all cookbooks that a specific cookbook update would imply.