### PR TITLE
Add fix to sort tags by version, not alphabetically

### DIFF
--- a/lib/policyfile.rb
+++ b/lib/policyfile.rb
@@ -145,7 +145,22 @@ class PolicyChangelog
   # @param repo [Git::Base] Git repository object
   # @return [String] Git tag versioning type
   def tag_format(repo)
-    repo.tags.last.name[/^v/] ? 'v' : ''
+    sort_by_version(repo.tags).last.name[/^v/] ? 'v' : ''
+  end
+
+  # Sort tags by version and filter out invalid version tags
+  #
+  # @param tags [Array<Git::Object::Tag>] git tags
+  # @return [Array] git tags sorted by version
+  def sort_by_version(tags)
+    tags.sort_by do |t|
+      begin
+        Gem::Version.new(t.name.gsub(/^v/, ''))
+      rescue ArgumentError => e
+        # Skip tag if version is not valid (i.e. a String)
+        Gem::Version.new(nil) if e.to_s.include?('Malformed version number string')
+      end
+    end
   end
 
   # Formats commit changelog to be more readable

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe PolicyChangelog do
 
   let(:url) { 'https://supermarket.chef.io/api/v1/cookbooks/users' }
 
+  let(:tags) do
+    [
+      double(name: '1.0.0'),
+      double(name: '0.9.1'),
+      double(name: 'v1.0.5'),
+      double(name: 'v1.1.1'),
+      double(name: 'invalid'),
+      double(name: '5.2.1'),
+      double(name: 'v0.1.1')
+    ]
+  end
+
   before(:each) do
     stub_request(:get, 'https://supermarket.chef.io/api/v1/cookbooks/users').to_return(
       status: 200,
@@ -209,12 +221,24 @@ RSpec.describe PolicyChangelog do
 
       it 'detects type for regular tag' do
         allow(repo).to receive_message_chain(:tags, :last, :name).and_return('1.0.0')
+        allow(changelog).to receive(:sort_by_version).and_return(repo.tags)
         expect(changelog.tag_format(repo)).to eq('')
       end
 
       it 'detects type for v-tag' do
         allow(repo).to receive_message_chain(:tags, :last, :name).and_return('v1.0.0')
+        allow(changelog).to receive(:sort_by_version).and_return(repo.tags)
         expect(changelog.tag_format(repo)).to eq('v')
+      end
+    end
+  end
+
+  describe '#sort_by_version' do
+    context 'when sorting' do
+      it 'sorts' do
+        expect(changelog.sort_by_version(tags).map(&:name)).to eq(
+          %w[invalid v0.1.1 0.9.1 1.0.0 v1.0.5 v1.1.1 5.2.1]
+        )
       end
     end
   end


### PR DESCRIPTION
Handles a Git::GitExecuteError which appears because of bad
recognition of versioning type and tag name sorting - reverse
alphabetical instead of sorting from first to latest. Invalid
version tags are pushed behind the first version.