### PR TITLE
Expose api method to compute changelog without updating policy

### DIFF
--- a/lib/policyfile.rb
+++ b/lib/policyfile.rb
@@ -206,10 +206,18 @@ class PolicyChangelog
                           else
                             updated_cookbooks.select { |name, _data| @cookbooks_to_update.include?(name) }
                           end
-    sources = {}
-    changelog_cookbooks.each_key do |name|
-      sources[name] = get_source_url(lock_target['cookbook_locks'][name]['source_options'])
-    end
-    changelog_cookbooks.deep_merge(sources).map { |name, data| format_output(name, data) }.join("\n")
+    generate_changelog_from_versions(changelog_cookbooks)
+  end
+
+  # Generates Policyfile changelog
+  #
+  # @param cookbook_versions. Format is { 'NAME'  => { 'current_version' => 'VERSION', 'target_version' => 'VERSION' }
+  # @return [String] formatted version changelog
+  def generate_changelog_from_versions(cookbook_versions)
+    lock_current = read_policyfile_lock(@policyfile_dir)
+    sources = cookbook_versions.keys.map do |name|
+      [name, get_source_url(lock_current['cookbook_locks'][name]['source_options'])]
+    end.to_h
+    cookbook_versions.deep_merge(sources).map { |name, data| format_output(name, data) }.join("\n")
   end
 end

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -273,6 +273,28 @@ RSpec.describe PolicyChangelog do
     end
   end
 
+  describe '#generate_changelog_from_versions' do
+    context 'when given origin/target versions' do
+      it 'generate the right changelog' do
+        expect(changelog).not_to receive(:update_policyfile_lock)
+
+        origin_and_target = {
+          'users' => { 'current_version' => '4.0.0', 'target_version' => '5.0.0' }
+        }
+
+        allow(changelog).to receive(:git_changelog)
+          .with(instance_of(String), '4.0.0', '5.0.0')
+          .and_return('e1b971a Add test commit message')
+
+        output = "\nChangelog for users: 4.0.0->5.0.0\n" \
+          "==================================\n"         \
+          "e1b971a Add test commit message"
+
+        expect(changelog.generate_changelog_from_versions(origin_and_target)).to eq(output)
+      end
+    end
+  end
+
   describe '#generate_changelog' do
     context 'when generating a changelog' do
       it 'detects type for regular tag' do


### PR DESCRIPTION
By default knife-changelog updates policyfile under the hood.
In some cases, we already have updated the policy and simply want to get
changelog for some cookbooks between version X and Y.

Change-Id: I48587727a35c89a5b569d0e43d9764e80658edb4