### PR TITLE
Correct handling of new cookbooks

### DIFF
--- a/knife-changelog.gemspec
+++ b/knife-changelog.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'knife-changelog'
-  spec.version       = '1.2.0'
+  spec.version       = '1.2.1'
   spec.authors       = ['Gregoire Seux']
   spec.email         = ['kamaradclimber@gmail.com']
   spec.summary       = 'Facilitate access to cookbooks changelog'

--- a/lib/knife/changelog/policyfile.rb
+++ b/lib/knife/changelog/policyfile.rb
@@ -180,8 +180,7 @@ class PolicyChangelog
     output.join("\n")
   end
 
-  # Filters out cookbooks which are not updated, are not used after update or
-  # are newly added as dependencies during update
+  # Filters out cookbooks which are not updated, are not used after update
   #
   # @param [Hash] cookbook versions and source url data
   # @return [true, false]
@@ -215,9 +214,9 @@ class PolicyChangelog
   # @return [String] formatted version changelog
   def generate_changelog_from_versions(cookbook_versions)
     lock_current = read_policyfile_lock(@policyfile_dir)
-    sources = cookbook_versions.keys.map do |name|
-      [name, get_source_url(lock_current['cookbook_locks'][name]['source_options'])]
-    end.to_h
+    sources = cookbook_versions.map do |name, data|
+      [name, get_source_url(lock_current['cookbook_locks'][name]['source_options'])] if data['current_version']
+    end.compact.to_h
     cookbook_versions.deep_merge(sources).map { |name, data| format_output(name, data) }.join("\n")
   end
 end

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -279,16 +279,24 @@ RSpec.describe PolicyChangelog do
         expect(changelog).not_to receive(:update_policyfile_lock)
 
         origin_and_target = {
-          'users' => { 'current_version' => '4.0.0', 'target_version' => '5.0.0' }
+          'users' => { 'current_version' => '4.0.0', 'target_version' => '5.0.0' },
+          'new_cookbook' => { 'target_version' => '8.0.0' }
         }
 
         allow(changelog).to receive(:git_changelog)
           .with(instance_of(String), '4.0.0', '5.0.0')
           .and_return('e1b971a Add test commit message')
 
-        output = "\nChangelog for users: 4.0.0->5.0.0\n" \
-          "==================================\n"         \
-          "e1b971a Add test commit message"
+        output = <<~COMMIT.chomp
+
+          Changelog for users: 4.0.0->5.0.0
+          ==================================
+          e1b971a Add test commit message
+
+          Changelog for new_cookbook: ->8.0.0
+          ====================================
+          Cookbook was not in the Policyfile.lock.json
+        COMMIT
 
         expect(changelog.generate_changelog_from_versions(origin_and_target)).to eq(output)
       end
@@ -305,7 +313,7 @@ RSpec.describe PolicyChangelog do
 
         output = "\nChangelog for users: 4.0.0->5.3.1\n" \
           "==================================\n"         \
-          "e1b971a Add test commit message"
+          'e1b971a Add test commit message'
 
         expect(changelog.generate_changelog).to eq(output)
       end


### PR DESCRIPTION
This patch correct behavior of changelog when a new cookbook is
introduced as a dependency

Change-Id: I9b57421ab34b05a7a65a1cc4e62df308404ad0e5