### PR TITLE
A policyfile update that fails doesn't raise an error

### DIFF
--- a/knife-changelog.gemspec
+++ b/knife-changelog.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'knife-changelog'
-  spec.version       = '1.2.3'
+  spec.version       = '1.2.4'
   spec.authors       = ['Gregoire Seux']
   spec.email         = ['kamaradclimber@gmail.com']
   spec.summary       = 'Facilitate access to cookbooks changelog'

--- a/lib/knife/changelog/policyfile.rb
+++ b/lib/knife/changelog/policyfile.rb
@@ -141,7 +141,8 @@ class PolicyChangelog
         Gem::Version.new(t.name.gsub(/^v/, ''))
       rescue ArgumentError => e
         # Skip tag if version is not valid (i.e. a String)
-        Gem::Version.new(nil) if !e.message.nil? && e.message.include?('Malformed version number string')
+        raise unless e.message && e.message.include?('Malformed version number string')
+        Gem::Version.new('0.0.0')
       end
     end
   end

--- a/lib/knife/changelog/policyfile.rb
+++ b/lib/knife/changelog/policyfile.rb
@@ -29,7 +29,7 @@ class PolicyChangelog
     backup_dir = Dir.mktmpdir
     FileUtils.cp(File.join(@policyfile_dir, 'Policyfile.lock.json'), backup_dir)
     updater = ChefDK::Command::Update.new
-    updater.run([@policyfile_path, @cookbooks_to_update].flatten)
+    raise "Error updating Policyfile lock #{@policyfile_path}" unless updater.run([@policyfile_path, @cookbooks_to_update].flatten).zero?
     updated_policyfile_lock = read_policyfile_lock(@policyfile_dir)
     FileUtils.cp(File.join(backup_dir, 'Policyfile.lock.json'), @policyfile_dir)
     updated_policyfile_lock
@@ -55,7 +55,7 @@ class PolicyChangelog
   # @return [Hash] cookbooks with their versions
   def versions(locks, type)
     raise 'Use "current" or "target" as type' unless %w[current target].include?(type)
-    raise 'Cookbook locks empty or nil' if locks.nil? or locks.empty?
+    raise 'Cookbook locks empty or nil' if locks.nil? || locks.empty?
     cookbooks = {}
     locks.each do |name, data|
       cookbooks[name] = if data['source_options'].keys.include?('git')
@@ -141,7 +141,7 @@ class PolicyChangelog
         Gem::Version.new(t.name.gsub(/^v/, ''))
       rescue ArgumentError => e
         # Skip tag if version is not valid (i.e. a String)
-        Gem::Version.new(nil) if e.to_s.include?('Malformed version number string')
+        Gem::Version.new(nil) if !e.message.nil? && e.message.include?('Malformed version number string')
       end
     end
   end

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe PolicyChangelog do
 
   let(:url) { 'https://supermarket.chef.io/api/v1/cookbooks/users' }
 
+  let(:fake_update) { double('fake_update') }
+
   let(:tags) do
     [
       double(name: '1.0.0'),
@@ -309,6 +311,14 @@ RSpec.describe PolicyChangelog do
           'e1b971a Add test commit message'
 
         expect(changelog.generate_changelog).to eq(output)
+      end
+      it 'raises an exception' do
+        allow(ChefDK::Command::Update).to receive(:new).and_return(fake_update)
+        allow(fake_update).to receive(:run).and_return(1)
+        allow(changelog).to receive(:git_changelog)
+          .and_return('e1b971a Add test commit message')
+
+        expect { changelog.generate_changelog }.to raise_error(RuntimeError)
       end
     end
   end


### PR DESCRIPTION
It returns 1, so we raise an error, as we can't generate a changelog if
the update has failed

Also fix or -> ||