### PR TITLE
Support various style of source_url

### DIFF
--- a/lib/knife/changelog/changelog.rb
+++ b/lib/knife/changelog/changelog.rb
@@ -239,10 +239,15 @@ class KnifeChangelog
       c
     end
 
+    GERRIT_REGEXP = %r{^(.*)/[^/]+/[^/]+(?:\.git)$}
     def linkify(url, changelog)
-      changelog.map do |line|
-        line.gsub(/^([a-f0-9]+) (.*)$/, '\2 (%s/commit/\1) ' % [url.chomp('.git')])
-      end
+      format = case url
+               when /gitlab/, /github/
+                 "\\2 (#{url.chomp('.git')}/commit/\\1)"
+               when GERRIT_REGEXP
+                 "\\2 (#{::Regexp.last_match(1)}/#/q/\\1)"
+               end
+      format ? changelog.map { |line| line.sub(/^([a-f0-9]+) (.*)$/, format) } : changelog
     end
 
     def https_url(location)

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -92,6 +92,35 @@ RSpec.describe PolicyChangelog do
     end
   end
 
+  describe '#linkify' do
+    subject { KnifeChangelog::Changelog.new(config) }
+    let(:config) { double('config') }
+    let(:changelog) do
+      ['9363423 Leverage criteo-flavor 3.11 to benefit from labels']
+    end
+    context 'when url is gitlab style' do
+      let(:url) { 'https://gitlab.com/chef-cookbooks/criteo-rackguru.git' }
+
+      it 'creates a gitlab style link' do
+        expect(subject.linkify(url, changelog).first).to match(%r{https://gitlab.com/chef-cookbooks/criteo-rackguru/commit/9363423})
+      end
+    end
+
+    context 'when url is github style' do
+      let(:url) { 'https://github.com/chef-cookbooks/criteo-rackguru.git' }
+      it 'creates a github style link' do
+        expect(subject.linkify(url, changelog).first).to match(%r{https://github.com/chef-cookbooks/criteo-rackguru/commit/9363423})
+      end
+    end
+
+    context 'when url has no known style' do
+      let(:url) { 'https://review.mycompany.com/chef-cookbooks/criteo-rackguru.git' }
+      it 'creates a gerrit style link' do
+        expect(subject.linkify(url, changelog).first).to match(%r{https://review.mycompany.com/#/q/9363423})
+      end
+    end
+  end
+
   describe '#versions' do
     context 'when type is current' do
       it 'returns correct current versions' do


### PR DESCRIPTION
Github and gitlab were implicicely supported.
Now every unknown url will be treated as gerrit style url.

Next step would be to allow the user to be explicit

Change-Id: If2f61019a00dd7f77cf033b69152375a6a6daab4