### PR TITLE
Add a way to fail in case of cookbook downgrade (in Policifile)

### DIFF
--- a/lib/chef/knife/changelog.rb
+++ b/lib/chef/knife/changelog.rb
@@ -42,6 +42,12 @@ class Chef
              long: '--submodules SUBMODULE[,SUBMODULE]',
              description: 'Submoduless to check for changes as well (comma separated)'
 
+      option :prevent_downgrade,
+             long: '--prevent-downgrade',
+             description: 'Fail if knife-changelog detect a cookbook downgrade',
+             boolean: true,
+             default: false
+
       option :policyfile,
              long: '--policyfile PATH',
              description: 'Link to policyfile, defaults to "Policyfile.rb"',


### PR DESCRIPTION
This feature target only policyfiles.
In some cases we don't want cookbooks to be downgraded.
Knife-changelog has all the info to check for this condition and fail.