### PR TITLE
Fix downgrade validation method to skip non-sementic versions

### DIFF
--- a/knife-changelog.gemspec
+++ b/knife-changelog.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'knife-changelog'
-  spec.version       = '1.4.0'
+  spec.version       = '1.4.1'
   spec.authors       = ['Gregoire Seux']
   spec.email         = ['kamaradclimber@gmail.com']
   spec.summary       = 'Facilitate access to cookbooks changelog'


### PR DESCRIPTION
Cookbooks referenced by git may not follow a sementic versioning.
Knife changelog used to reference their version using the commit sha1, but it is hard to determine wether one sha1 is downgrading another.

A simple workaround to this issue limited to the sole usecase of git references, lets just skip them.