### PR TITLE
Force config as a String when we pass it to Log.info

### DIFF
--- a/lib/chef/knife/changelog.rb
+++ b/lib/chef/knife/changelog.rb
@@ -64,7 +64,7 @@ class Chef
              description: 'Update Berksfile'
 
       def run
-        Log.info config
+        Log.info config.to_s
         if config[:policyfile] && File.exist?(config[:policyfile])
           puts PolicyChangelog.new(
             @name_args,


### PR DESCRIPTION
* Pass config as is to Log.info can be confusing since it's a list of
  symbols
* Log.info understands it as a list of keywords and not as someting to
  convert as a String
* We can force this

Change-Id: Iaae4099edfcbebb54f7a852b19678a3d84302066