### PR TITLE
poliycyfile: add minimal support for repository with multiple cookbooks

### DIFF
--- a/lib/knife/changelog/policyfile.rb
+++ b/lib/knife/changelog/policyfile.rb
@@ -127,7 +127,7 @@ class PolicyChangelog
       path = ::File.join(repo.dir.to_s, path)
       ::Chef::Cookbook::Metadata.new.tap { |m| m.from_file(path) }.name == cookbook
     end
-    raise "Impossible to find matching metadata for #{cookbook} in #{remo.remote.url}" unless metadata_path
+    raise "Impossible to find matching metadata for #{cookbook} in #{repo.remote.url}" unless metadata_path
     ::File.dirname(metadata_path)
   end
 

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -238,11 +238,16 @@ RSpec.describe PolicyChangelog do
 
     context 'when tag invalid and able to correct' do
       it 'returns correct git tag' do
-        allow(repo).to receive(:checkout).with(/v1.0/).and_raise(::Git::GitExecuteError)
         allow(repo).to receive(:checkout).with('1.0.0').and_raise(::Git::GitExecuteError)
-        allow(repo).to receive(:checkout).with('1.0').and_return(true)
 
-        expect(changelog.git_ref('1.0.0', repo)).to eq('1.0')
+        tags = %w[v1.0.0 1.0 v1.0 cookbook_name-1.0.0 cookbook_name-1.0 cookbook_name-v1.0.0 cookbook_name-v1.0]
+        tags.each do |valid_result|
+          allow(repo).to receive(:checkout).with(valid_result).and_return(true)
+          tags.reject { |v| v == valid_result }.each do |invalid_result|
+            allow(repo).to receive(:checkout).with(invalid_result).and_raise(::Git::GitExecuteError)
+          end
+          expect(changelog.git_ref('1.0.0', repo, 'cookbook_name')).to eq valid_result
+        end
       end
     end
 

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe PolicyChangelog do
         allow(changelog).to receive(:git_ref).with('1.0.0', any_args).and_return('v1.0.0')
         allow(changelog).to receive(:git_ref).with('1.0.1', any_args).and_return('v1.0.1')
         allow(changelog).to receive(:correct_tags)
-        allow(git_repo).to receive_message_chain(:log, :between)
+        allow(git_repo).to receive_message_chain(:log, :path, :between)
           .with('v1.0.0', 'v1.0.1')
           .and_return([git_commit])
 
@@ -308,7 +308,7 @@ RSpec.describe PolicyChangelog do
         }
 
         allow(changelog).to receive(:git_changelog)
-          .with(instance_of(String), '4.0.0', '5.0.0')
+          .with(instance_of(String), '4.0.0', '5.0.0', 'users')
           .and_return('e1b971a Add test commit message')
 
         output = <<~COMMIT.chomp


### PR DESCRIPTION
Cookbooks authors may have git repositories holding multiple cookbooks.
This commit adapt the Policyfile git_changelog method to first find the directory containing the metadata.rb which matches a specific cookbook then it uses it to compute the changelog.

As there can't be 2 branches or tags with the same name, the versioning is also different in such "mono-repository" so the git_changelog method has also been adapted to search for tags/branches prefixed by the name
of the cookbook.
   i.e. <cookbook_name>-1.0.0 or <cookbook_name>-v1.0.0

Cookbooks with metadata.json or different versioning system are not yet supported.