### PR TITLE
Enable generation of git submodule changelog independently of berkshelf

### DIFF
--- a/lib/knife/changelog/changelog.rb
+++ b/lib/knife/changelog/changelog.rb
@@ -18,7 +18,7 @@ class KnifeChangelog
       end
     end
 
-    def initialize(config)
+    def initialize(config = {})
       @tmp_prefix = 'knife-changelog'
       @config   = config
       @tmp_dirs = []

--- a/lib/knife/changelog/git_submodule.rb
+++ b/lib/knife/changelog/git_submodule.rb
@@ -1,0 +1,18 @@
+# coding: utf-8
+require 'chef/log'
+require_relative 'changelog'
+
+class KnifeChangelog
+  class GitSubmodule < Changelog
+
+    def run(submodules)
+      raise ::ArgumentError "Submodules must be an Array instead of #{submodules.inspect}" unless submodules.is_a?(::Array)
+      submodules.map do |submodule|
+        Chef::Log.debug "Checking changelog for #{submodule} (submodule)"
+        format_changelog(submodule, *handle_submodule(submodule))
+      end.compact.join("\n")
+    ensure
+      clean
+    end
+  end
+end


### PR DESCRIPTION
There is no reason to use berkshelf to generate the changelog of a git submodule.
With this change one can independently get their submodules changelog by calling:

```ruby
  ::KnifeChangelog::GitSubmodule.new.run('submodule1', ...)
```

The Berkshelf changelog generator is still generating submodules as an option.