### PR TITLE
Mutualize git clones

### DIFF
--- a/knife-changelog.gemspec
+++ b/knife-changelog.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'webmock'
 
-  spec.add_dependency  'chef'
   spec.add_dependency  'chef-cli'
   spec.add_dependency  'deep_merge'
   spec.add_dependency  'git'

--- a/lib/knife/changelog/policyfile.rb
+++ b/lib/knife/changelog/policyfile.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'chef'
 require 'chef/knife'
 require 'chef-cli/command/update'
 require 'chef-cli/command/install'

--- a/spec/unit/policyfile_spec.rb
+++ b/spec/unit/policyfile_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe PolicyChangelog do
         }
 
         allow(changelog).to receive(:git_changelog)
-          .with(instance_of(String), '4.0.0', '5.0.0', 'users')
+          .with(instance_of(String), '4.0.0', '5.0.0', 'users', work_dir: nil)
           .and_return('e1b971a Add test commit message')
 
         output = <<~COMMIT.chomp


### PR DESCRIPTION
 When using multiple cookbooks from a mono-repo, we used to clone the  repo multiple times. 
=> Now we clone only once.

 Also use a single TmpDir for all operations (git clone & policy update)  which will be clean at the end. Former code was creating many tmpdir.