### PR TITLE
Fix args passed to generate_changelog method

### DIFF
--- a/knife-changelog.gemspec
+++ b/knife-changelog.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'knife-changelog'
-  spec.version       = '4.1.0'
+  spec.version       = '4.1.1'
   spec.authors       = ['Gregoire Seux']
   spec.email         = ['kamaradclimber@gmail.com']
   spec.summary       = 'Facilitate access to cookbooks changelog'

--- a/lib/chef/knife/changelog.rb
+++ b/lib/chef/knife/changelog.rb
@@ -35,7 +35,7 @@ class Chef
           @name_args,
           config[:policyfile],
           config[:with_dependencies]
-        ).generate_changelog(config[:prevent_downgrade])
+        ).generate_changelog(prevent_downgrade: config[:prevent_downgrade])
       end
     end
   end


### PR DESCRIPTION
This should be a keyword arg, not directly a positional boolean param.